### PR TITLE
Use mechanism as a function.

### DIFF
--- a/src/riskcal/dpsgd.py
+++ b/src/riskcal/dpsgd.py
@@ -75,7 +75,8 @@ class CTDAccountant:
             total += steps
         return total
 
-    def mechanism(self):
+    @classmethod
+    def mechanism(cls):
         return "ctd"
 
     # The following methods are copied from https://opacus.ai/api/_modules/opacus/accountants/accountant.html#IAccountant
@@ -109,7 +110,7 @@ class CTDAccountant:
         if destination is None:
             destination = {}
         destination["history"] = deepcopy(self.history)
-        destination["mechanism"] = self.__class__.mechanism
+        destination["mechanism"] = self.mechanism()
         return destination
 
     def load_state_dict(self, state_dict):
@@ -138,10 +139,10 @@ class CTDAccountant:
                 "state_dict does not have the key `mechanism`."
                 " Cannot be loaded into Privacy Accountant."
             )
-        if self.__class__.mechanism != state_dict["mechanism"]:
+        if self.mechanism() != state_dict["mechanism"]:
             raise ValueError(
                 f"state_dict of {state_dict['mechanism']} cannot be loaded into "
-                f" Privacy Accountant with mechanism {self.__class__.mechanism}"
+                f" Privacy Accountant with mechanism {self.mechanism()}"
             )
         self.history = state_dict["history"]
 


### PR DESCRIPTION
Accountant.mechanism is used as a class property in opacus.IAccountant state_dict methods, while it is an overloadable function in the code. It breaks state_dict functionality both ways.